### PR TITLE
Swap larastan package for new one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^8.0",
-        "nunomaduro/larastan": "^2.0.0",
+        "larastan/larastan": "^2.0.0",
         "october/rain": "^3.0.0"
     },
     "license": "MIT",


### PR DESCRIPTION
Package nunomaduro/larastan is abandoned, you should avoid using it. Use larastan/larastan instead.